### PR TITLE
Added an additional catch for RecordDeclaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ compileJava {
 }
 
 dependencies {
-    implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.22.1'
+    implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.24.2'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.beust:jcommander:1.81'
     implementation 'org.jsoup:jsoup:1.13.1'

--- a/src/main/java/io/github/bensku/tsbind/AstGenerator.java
+++ b/src/main/java/io/github/bensku/tsbind/AstGenerator.java
@@ -94,6 +94,11 @@ public class AstGenerator {
 			} catch (UnsolvedSymbolException e) {
 				System.err.println("failed to resolve symbol " + e.getName() + " in " + source.name + "; omitting entire type!");
 				return Optional.empty();
+			} catch (Exception e) {
+				// RecordDeclaration doesn't get caught by the above. 
+				// StructuresLocateEvent in Paper 1.18 is triggering this.
+				System.err.println("failed to resolve in " + source.name + "; omitting entire type!");
+				return Optional.empty();
 			}
 		} else {
 			return Optional.empty();

--- a/src/main/java/io/github/bensku/tsbind/AstGenerator.java
+++ b/src/main/java/io/github/bensku/tsbind/AstGenerator.java
@@ -307,7 +307,7 @@ public class AstGenerator {
 	private PublicFilterResult filterPublicTypes(List<ClassOrInterfaceType> types) {
 		PublicFilterResult result = new PublicFilterResult();
 		for (ClassOrInterfaceType type : types) {
-			ResolvedReferenceType resolved = type.resolve();
+			ResolvedReferenceType resolved = type.resolve().asReferenceType();
 			if (isPublic(resolved.getTypeDeclaration().orElse(null))) {
 				result.publicTypes.add(resolved);
 			} else {


### PR DESCRIPTION
Hey! I want to start off by stating that this library is amazing. Thank you for your hard work! It is an absolute game changer. 

When I was trying to build it against `io.papermc.paper:paper-api:1.19.1-R0.1-SNAPSHOT`, it was failing specifically at https://jd.papermc.io/paper/1.19/io/papermc/paper/event/world/StructuresLocateEvent.html. It seems that JavaParser doesn't understand `record` just yet (https://github.com/javaparser/javaparser/issues/2446, https://github.com/javaparser/javaparser/issues/3556).

I went ahead and added an additional catch, so the tool can still build and updated the JavaParser dependency. 

With these changes, I was able to produce:

![image](https://user-images.githubusercontent.com/13123338/181411473-6dda773e-6a9d-452a-a528-d28d499e99dd.png)

